### PR TITLE
Make config work with eslint 2 with respect to module imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "ecmaFeatures": {
       "modules": true
     },
+    "parserOptions": {
+      "sourceType": "module"
+    },
     "rules": {
       "comma-dangle": [
         1,


### PR DESCRIPTION
My atom was unable to lint properly without this. It seems there is a breaking change between eslint 1 and 2. I also think "ecmaFeatures" should be relocated into "parserOptions", but it doesnt seem necessary. 
